### PR TITLE
Replace several thrown? test with thrown-with-msg?

### DIFF
--- a/src/clojure/clojurewerkz/titanium/graph.clj
+++ b/src/clojure/clojurewerkz/titanium/graph.clj
@@ -36,7 +36,7 @@
     conf))
 
 (defprotocol TitaniumGraph
-  (^KeyIndexableGraph open [input] "Opens a new graph"))
+  (^com.tinkerpop.blueprints.KeyIndexableGraph open [input] "Opens a new graph"))
 
 (extend-protocol TitaniumGraph
   String

--- a/test/clojurewerkz/titanium/edges_test.clj
+++ b/test/clojurewerkz/titanium/edges_test.clj
@@ -237,8 +237,8 @@
          (is (= 1 (ted/get edge :a)))
          (is (= 0 (ted/get edge :b)))
          (ted/connect! v1 :connexion v2)
-         (is (thrown? Throwable #"There were 2 vertices returned."
-                      (ted/unique-upconnect! v1 :connexion v2))))))
+         (is (thrown-with-msg? Throwable #"There were 2 vertices returned."
+                               (ted/unique-upconnect! v1 :connexion v2))))))
     (tg/shutdown)
     (clear-db)))
 

--- a/test/clojurewerkz/titanium/graph_test.clj
+++ b/test/clojurewerkz/titanium/graph_test.clj
@@ -49,7 +49,7 @@
       (is (= StandardVertex (type vertex)))))
 
   (testing "Stored graph"
-    (is (thrown? Throwable #"transact!" (tv/create!))))
+    (is (thrown-with-msg? Throwable #"transact!" (tv/create!))))
 
   (testing "Dueling transactions"
     (tg/transact!

--- a/test/clojurewerkz/titanium/vertices_test.clj
+++ b/test/clojurewerkz/titanium/vertices_test.clj
@@ -204,8 +204,8 @@
        (is (= 22
               (tv/get (tv/refresh v1-a) :age)
               (tv/get (tv/refresh v1-b) :age)))       
-       (is (thrown? Throwable #"There were 2 vertices returned."
-                    (tv/unique-upsert! :last-name {:last-name "Maril"}))))))
+       (is (thrown-with-msg? Throwable #"There were 2 vertices returned."
+                             (tv/unique-upsert! :last-name {:last-name "Maril"}))))))
   
   (tg/shutdown)
   (clear-db))


### PR DESCRIPTION
because they had regex's after them which are ignored by a thrown?
test.

Also added a package path to a Java class used as a return type hint,
because tools.analyzer.jvm requires it to avoid throwing an exception.
It is harmless for Clojure.

Found using a pre-release version of the Eastwood Clojure lint tool.
